### PR TITLE
Fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ install:
   - npm install -g elm@~0.18.0
   - npm install -g elm-test
   - npm install
-  - git clone https://github.com/NoRedInk/elm-ops-tooling
-  - elm-ops-tooling/with_retry.rb elm package install --yes
 
 script:
   - "elm-test --verbose"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
 
 install:
   - npm install -g elm@~0.18.0
-  - npm install -g elm-test
+  - npm install -g elm-test@0.18.2
   - npm install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,11 @@ cache:
     - tests/elm-stuff/build-artifacts
 
 install:
-  - npm install -g elm elm-test
+  - npm install -g elm@~0.18.0
+  - npm install -g elm-test
   - npm install
   - git clone https://github.com/NoRedInk/elm-ops-tooling
   - elm-ops-tooling/with_retry.rb elm package install --yes
 
 script:
-  - elm-test
+  - "elm-test --verbose"

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,11 +1,11 @@
 port module Main exposing (..)
 
 import Tests
-import Test.Runner.Node exposing (run)
+import Test.Runner.Node exposing (TestProgram, run)
 import Json.Encode exposing (Value)
 
 
-main : Program Value
+main : TestProgram
 main =
     run emit Tests.all
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,13 +9,13 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
-        "elm-community/list-extra": "3.1.0 <= v < 4.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0",
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "elm-community/list-extra": "4.0.0 <= v < 5.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/mouse": "1.0.0 <= v < 2.0.0",
         "justinmimbs/elm-date-extra": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/node-test-runner": "2.0.0 <= v < 3.0.0"
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
## Status

Tests pass on local:
```
 aaron   elm-18-test-fixes  ⋯  elm-stuff  packages  elm-calendar  elm-test
Success! Compiled 2 modules.                                        
Successfully generated /tmp/elm_test_117528-24594-1v9nyu0.od7hftuik9.js

elm-test
--------

Running 12 tests. To reproduce these results, run: elm-test --seed 17995816


TEST RUN PASSED

Duration: 32 ms
Passed:   12
Failed:   0

 aaron   elm-18-test-fixes  ⋯  elm-stuff  packages  elm-calendar  elm --version
0.18.0
```

## Todo

Wait for Travis green

It should make it possible to tag a release per https://github.com/thebritican/elm-calendar/issues/17